### PR TITLE
v2.2.58 (2016-02-27)

### DIFF
--- a/src/com/owera/xaps/web/Page.java
+++ b/src/com/owera/xaps/web/Page.java
@@ -440,7 +440,6 @@ public enum Page {
 	 */
 	public static void addRequiredPages(List<Page> list) {
 		list.add(LOGIN);
-		list.add(PERMISSIONS);
 		if (list.contains(TOPMENU_ADV)) {
 			list.add(CREATETRIGGER);
 			list.add(TRIGGEROVERVIEW);

--- a/src/com/owera/xaps/web/app/menu/MenuServlet.java
+++ b/src/com/owera/xaps/web/app/menu/MenuServlet.java
@@ -143,7 +143,7 @@ public class MenuServlet extends HttpServlet {
 	private static List<String> getPagesAllowed(String sessionId) {
 		SessionData sessionData = SessionCache.getSessionData(sessionId);
 		if (sessionData.getUser() != null && !sessionData.getUser().getAccess().equals(Users.ACCESS_ADMIN))
-			return sessionData.getUser().getAllowedPages();
+			return sessionData.getUser().getAllowedPages(sessionId);
 		else if (sessionData.getUser() == null || (sessionData.getUser() != null && sessionData.getUser().getAccess().equals(Users.ACCESS_ADMIN)))
 			return Page.getAllPagesAsString();
 		return null;

--- a/src/com/owera/xaps/web/app/page/staging/StagingPage.java
+++ b/src/com/owera/xaps/web/app/page/staging/StagingPage.java
@@ -1,5 +1,6 @@
 package com.owera.xaps.web.app.page.staging;
 
+import java.util.List;
 import java.util.Map;
 
 import com.owera.xaps.dbi.Users;
@@ -22,8 +23,10 @@ public class StagingPage extends AbstractWebPage {
 	public void process(ParameterParser params, Output outputHandler) throws Exception {
 		Map<String, Object> root = outputHandler.getTemplateMap();
 		
-		WebUser user = SessionCache.getSessionData(params.getSession().getId()).getUser();
-		boolean displayDistributorLink = (user!=null&&user.getAccess().equals(Users.ACCESS_ADMIN))||(user!=null && user.getAllowedPages()!=null && user.getAllowedPages().contains("distributors"));
+		String sessionId = params.getSession().getId();
+		WebUser user = SessionCache.getSessionData(sessionId).getUser();
+		List<String> allowedPages = user.getAllowedPages(sessionId);
+		boolean displayDistributorLink = (user!=null&&user.getAccess().equals(Users.ACCESS_ADMIN))||(user!=null && allowedPages!=null && allowedPages.contains("distributors"));
 		root.put("ADMIN", displayDistributorLink);
 		
 		outputHandler.setTemplatePathWithIndex("staging");

--- a/src/com/owera/xaps/web/app/security/LoginServlet.java
+++ b/src/com/owera/xaps/web/app/security/LoginServlet.java
@@ -232,7 +232,8 @@ public class LoginServlet extends HttpServlet implements Filter {
 
 		HttpServletResponse response = (HttpServletResponse) res;
 
-		SessionData sessionData = SessionCache.getSessionData(request.getSession().getId());
+		String sessionId = request.getSession().getId();
+		SessionData sessionData = SessionCache.getSessionData(sessionId);
 
 		sessionData.setUrlMap(urlMap);
 
@@ -241,7 +242,7 @@ public class LoginServlet extends HttpServlet implements Filter {
 		String page = request.getParameter("page");
 
 		if (user != null && page != null) {
-			List<String> allowedPages = user.getAllowedPages();
+			List<String> allowedPages = user.getAllowedPages(sessionId);
 			if (allowedPages.contains(page) || (allowedPages.size() == 1 && allowedPages.contains(WebConstants.ALL_PAGES))) {
 				if (checkTimeoutAndReturn(request, response))
 					return;

--- a/src/com/owera/xaps/web/app/security/WebUser.java
+++ b/src/com/owera/xaps/web/app/security/WebUser.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.owera.xaps.dbi.User;
 import com.owera.xaps.dbi.Users;
 import com.owera.xaps.web.Page;
+import com.owera.xaps.web.app.util.SessionCache;
 import com.owera.xaps.web.app.util.WebConstants;
 
 /**
@@ -35,7 +36,7 @@ public class WebUser extends User {
 	 *
 	 * @return A list of page ids
 	 */
-	public List<String> getAllowedPages() {
+	public List<String> getAllowedPages(String sessionId) {
 		if (allowedPages == null) {
 			String access = getAccess().split(";")[0];
 			if (access.startsWith("WEB[") && access.endsWith("]")) {
@@ -45,6 +46,9 @@ public class WebUser extends User {
 				List<String> list = new ArrayList<String>(arr);
 				List<Page> pages = Page.getPageValuesFromList(list);
 				Page.addRequiredPages(pages);
+				if (SessionCache.getSessionData(sessionId).getUser().isAdmin()) {
+					pages.add(Page.PERMISSIONS);
+				}
 				list = Page.getStringValuesFromList(pages);
 				allowedPages = list;
 			} else {
@@ -62,8 +66,8 @@ public class WebUser extends User {
 	 *
 	 * @return true, if is reports allowed
 	 */
-	public boolean isReportsAllowed() {
-		List<String> pages = getAllowedPages();
+	public boolean isReportsAllowed(String sessionId) {
+		List<String> pages = getAllowedPages(sessionId);
 		return pages.contains(Page.REPORT.getId()) || pages.contains(WebConstants.ALL_PAGES);
 	}
 

--- a/src/com/owera/xaps/web/app/security/WebUser.java
+++ b/src/com/owera/xaps/web/app/security/WebUser.java
@@ -62,16 +62,6 @@ public class WebUser extends User {
 	private List<String> allowedPages;
 
 	/**
-	 * Checks if is reports allowed.
-	 *
-	 * @return true, if is reports allowed
-	 */
-	public boolean isReportsAllowed(String sessionId) {
-		List<String> pages = getAllowedPages(sessionId);
-		return pages.contains(Page.REPORT.getId()) || pages.contains(WebConstants.ALL_PAGES);
-	}
-
-	/**
 	 * Checks if is authenticated.
 	 *
 	 * @return true, if is authenticated

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,5 @@
+v2.2.58 (2016-02-27)
+- ref: Only adding permissions page to tools menu if user is admin
 v2.2.57 (2014-11-08)
 - ref: Updated logic concerning branding of the product. Removed/changed some text referring specifically to FreeACS/Ping,
 added some logic to specify own brand. 

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,6 @@
 v2.2.58 (2016-02-27)
 - ref: Only adding permissions page to tools menu if user is admin
+- ref: removing unused method
 v2.2.57 (2014-11-08)
 - ref: Updated logic concerning branding of the product. Removed/changed some text referring specifically to FreeACS/Ping,
 added some logic to specify own brand. 


### PR DESCRIPTION
- ref: Only adding permissions page to tools menu if user is admin

This will effectively fix #7, unless there is use cases where some user that is not admin should be able to administer permissions for FreeACS, which I find peculiar.