### PR TITLE
v2.2.58 (2016-02-27)

### DIFF
--- a/src/com/owera/xaps/web/app/security/LoginServlet.java
+++ b/src/com/owera/xaps/web/app/security/LoginServlet.java
@@ -95,7 +95,7 @@ public class LoginServlet extends HttpServlet implements Filter {
 						String target = sessionData.getLastLoginTarget();
 						if (target == null || target.trim().length() == 0) //Idiot safe solution, to avoid any unknown problems
 							target = Page.SEARCH.getUrl();
-						response.sendRedirect(target);
+						response.sendRedirect(target.replaceAll("\\s", "%20"));
 					} else {
 						printLoginPage(request, response, sessionData);
 					}

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,5 @@
+v2.2.58 (2016-02-27)
+- ref: Fixed issue #11 with regards to redirect not working for unittype with space in the name after timing out
 v2.2.57 (2014-11-08)
 - ref: Updated logic concerning branding of the product. Removed/changed some text referring specifically to FreeACS/Ping,
 added some logic to specify own brand. 


### PR DESCRIPTION
- ref: Fixed issue #11 with regards to redirect not working for unittype with space in the name after timing out

This resolves #11 
